### PR TITLE
changes for angular 1.2.x

### DIFF
--- a/app/js/app.js
+++ b/app/js/app.js
@@ -1,4 +1,4 @@
-var app = angular.module("calculatorApplication", []).config(function ($routeProvider) {
+var app = angular.module("calculatorApplication", ["ngRoute"]).config(function ($routeProvider) {
 
     $routeProvider.when("/home", {
         templateUrl: "app/view/home.html",


### PR DESCRIPTION
If newer version is to be used (my case 1.2.28 against 1.0.7 used in the example), separate js import of angular-route.min.js for routing module ngRoute must be done in index.html and dependency declared for the module in app.js
