### PR TITLE
update for angular 1.2.28

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <script src="lib/js/angular.min.js" type="text/javascript"></script>
+    <script scr="lib/js/angular-route.min.js" type="text/javascript"></script>
     <script src="app/js/app.js" type="text/javascript"></script>
     <link href="app/style/default.css" rel="stylesheet" type="text/css">
 </head>


### PR DESCRIPTION
If newer version is to be used (my case 1.2.28 against 1.0.7 used in the example), separate js import of angular-route.min.js for routing module ngRoute must be done in index.html and dependency declared for the module in app.js
